### PR TITLE
fix: resolve release changelog generation issues

### DIFF
--- a/.github/workflows/build-abi3.yml
+++ b/.github/workflows/build-abi3.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  actions: write  # Required for uploading artifacts
 
 jobs:
   # Linux ABI3 builds

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  actions: write  # Required for uploading artifacts
 
 jobs:
   # Linux builds

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,42 +81,22 @@ jobs:
 
       - name: Generate changelog
         id: changelog
-        run: |
-          # Check if any tags exist
-          if git describe --tags --abbrev=0 >/dev/null 2>&1; then
-            # Get the latest tag
-            LATEST_TAG=$(git describe --tags --abbrev=0)
-
-            # Try to get previous tag
-            if PREVIOUS_TAG=$(git describe --tags --abbrev=0 $LATEST_TAG^ 2>/dev/null); then
-              echo "## Changes in $LATEST_TAG" > CHANGELOG.md
-              echo "" >> CHANGELOG.md
-
-              # Get commits between tags
-              git log --pretty=format:"- %s (%h)" $PREVIOUS_TAG..$LATEST_TAG >> CHANGELOG.md
-            else
-              # Only one tag exists, show all commits up to this tag
-              echo "## Changes in $LATEST_TAG" > CHANGELOG.md
-              echo "" >> CHANGELOG.md
-
-              # Get all commits up to the tag
-              git log --pretty=format:"- %s (%h)" $LATEST_TAG >> CHANGELOG.md
-            fi
-          else
-            # No tags exist, create changelog from all commits
-            echo "## Initial Release" > CHANGELOG.md
-            echo "" >> CHANGELOG.md
-            echo "This is the first release of diskcache_rs." >> CHANGELOG.md
-            echo "" >> CHANGELOG.md
-            echo "### All Changes:" >> CHANGELOG.md
-
-            # Get all commits
-            git log --pretty=format:"- %s (%h)" >> CHANGELOG.md
-          fi
-
-          echo "changelog<<EOF" >> $GITHUB_OUTPUT
-          cat CHANGELOG.md >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+        uses: jaywcjlove/changelog-generator@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filter-author: (loonghao|renovate\[bot\]|dependabot\[bot\]|Renovate Bot)
+          filter: '[R|r]elease[d]\s+[v|V]\d(\.\d+){0,2}'
+          template: |
+            ## Bugs
+            {{fix}}
+            ## Feature
+            {{feat}}
+            ## Improve
+            {{refactor,perf,clean}}
+            ## Misc
+            {{chore,style,ci}} 🔧 Nothing change}}
+            ## Unknown
+            {{__unknown__}}
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -124,11 +104,11 @@ jobs:
           path: release-artifacts
           merge-multiple: true
 
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
+      - uses: ncipollo/release-action@v1
         with:
-          body: ${{ steps.changelog.outputs.changelog }}
-          files: release-artifacts/*
-          draft: false
-          prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
-          generate_release_notes: true
+          artifacts: "release-artifacts/*"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          body: |
+            Comparing Changes: ${{ steps.changelog.outputs.compareurl }}
+
+            ${{ steps.changelog.outputs.changelog }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,9 @@ on:
   workflow_call:
 
 permissions:
-  contents: read
+  contents: write  # Required for creating releases and uploading artifacts
+  id-token: write  # Required for PyPI trusted publishing
+  attestations: write  # Required for artifact attestation
 
 jobs:
   # Call the build workflow to build standard wheels
@@ -17,12 +19,14 @@ jobs:
     uses: ./.github/workflows/build.yml
     permissions:
       contents: read
+      actions: write  # Required for uploading artifacts
 
   # Call the ABI3 build workflow to build universal wheels
   build-abi3:
     uses: ./.github/workflows/build-abi3.yml
     permissions:
       contents: read
+      actions: write  # Required for uploading artifacts
 
   # Call the CI workflow to run tests
   test:
@@ -73,7 +77,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [release]
     permissions:
-      contents: write
+      contents: write  # Required for creating releases
+      actions: read    # Required for downloading artifacts
+      attestations: write  # Required for artifact attestation
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "diskcache_rs"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "bincode",


### PR DESCRIPTION
## Problem

The current release workflow is failing during the "Generate changelog" step with the following errors:
- `Error: Unable to process file command 'output' successfully.`
- `Error: Invalid value. Matching delimiter not found 'EOF'`

## Solution

This PR fixes the release changelog generation issues by:

### 🔧 Technical Changes
- **Replace custom changelog generation** with `jaywcjlove/changelog-generator@main` action
- **Fix EOF delimiter issue** in GitHub Actions multiline output
- **Use `ncipollo/release-action`** for better release creation instead of `softprops/action-gh-release`
- **Follow conventional commit format** for changelog categorization

### 📋 Changelog Template
The new changelog will categorize commits as:
- **Bugs**: `fix` commits
- **Features**: `feat` commits  
- **Improvements**: `refactor`, `perf`, `clean` commits
- **Misc**: `chore`, `style`, `ci` commits
- **Unknown**: Other commit types

### 🎯 Benefits
- More reliable changelog generation
- Better categorization of changes
- Consistent with conventional commit standards
- Eliminates multiline output parsing errors

## Testing

This change should resolve the failing release workflow and enable successful GitHub releases with properly formatted changelogs.

---

**References:**
- Based on successful configuration from pypi-query-mcp-server project
- Follows GitHub Actions best practices for multiline outputs